### PR TITLE
POST/PATCH tests + routing refactor

### DIFF
--- a/app/controllers/api/v1/items/merchant_items_controller.rb
+++ b/app/controllers/api/v1/items/merchant_items_controller.rb
@@ -1,7 +1,7 @@
 module Api
     module V1 
         module Items
-            class MerchantController < ApplicationController
+            class MerchantItemsController < ApplicationController
                 def show
                     item = Item.find_by(id: params[:item_id])
 

--- a/app/controllers/api/v1/merchants/items_merchant_controller.rb
+++ b/app/controllers/api/v1/merchants/items_merchant_controller.rb
@@ -1,7 +1,7 @@
 module Api
     module V1
         module Merchants
-            class ItemsController < ApplicationController
+            class ItemsMerchantController < ApplicationController
 
                 def index
                     merchant = Merchant.find_by(id: params[:merchant_id])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,13 +13,13 @@
   namespace :api do
     namespace :v1 do
       resources :merchants, only: [:index, :show]
-        get "/merchants/:merchant_id/items", to: "merchants/items#index"
+        get "/merchants/:merchant_id/items", to: "merchants/items_merchant#index"
 
 
   get "/api/v1/merchants", to: "api/v1/merchants#index"
   get "/api/v1/merchants/:id", to: "api/v1/merchants#show"
   post "/api/v1/merchants", to: "api/v1/merchants#create"
-  patch "/api/v1/mechants/:id", to: "api/v1/merchants#update"
+  patch "/api/v1/merchants/:id", to: "api/v1/merchants#update"
 
   get "/api/v1/items", to: "api/v1/items#index"
   get "/api/v1/items/:id", to: "api/v1/items#show"
@@ -27,7 +27,7 @@
   put "/api/v1/items/:id", to: "api/v1/items#update"
 
       resources :items, only: [:index, :show]
-      get "/items/:item_id/merchant", to: "items/merchant#show"
+      get "/items/:item_id/merchant", to: "items/merchant_items#show"
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,15 +16,15 @@
         get "/merchants/:merchant_id/items", to: "merchants/items_merchant#index"
 
 
-  get "/api/v1/merchants", to: "api/v1/merchants#index"
-  get "/api/v1/merchants/:id", to: "api/v1/merchants#show"
-  post "/api/v1/merchants", to: "api/v1/merchants#create"
-  patch "/api/v1/merchants/:id", to: "api/v1/merchants#update"
+  get "/merchants", to: "merchants#index"
+  get "/merchants/:id", to: "merchants#show"
+  post "/merchants", to: "merchants#create"
+  patch "/merchants/:id", to: "merchants#update"
 
-  get "/api/v1/items", to: "api/v1/items#index"
-  get "/api/v1/items/:id", to: "api/v1/items#show"
-  post "/api/v1/items", to: "api/v1/items#create"
-  put "/api/v1/items/:id", to: "api/v1/items#update"
+  get "/items", to: "items#index"
+  get "/items/:id", to: "items#show"
+  post "/items", to: "items#create"
+  patch "/items/:id", to: "items#update"
 
       resources :items, only: [:index, :show]
       get "/items/:item_id/merchant", to: "items/merchant_items#show"

--- a/spec/requests/api/v1/merchants/items_request_spec.rb
+++ b/spec/requests/api/v1/merchants/items_request_spec.rb
@@ -77,9 +77,9 @@ RSpec.describe "Items API", type: :request do
 
             created_item = JSON.parse(response.body, symbolize_names: true)
             
-            expect(created_item[:data][:attributes][:name]).to be_a(String)
-            expect(created_item[:data][:attributes][:description]).to be_a(String)
-            expect(created_item[:data][:attributes][:unit_price]).to be_a(Float)
+            expect(created_item[:name]).to be_a(String)
+            expect(created_item[:description]).to be_a(String)
+            expect(created_item[:unit_price]).to be_a(Float)
         end
     end
 

--- a/spec/requests/api/v1/merchants/items_request_spec.rb
+++ b/spec/requests/api/v1/merchants/items_request_spec.rb
@@ -62,4 +62,40 @@ RSpec.describe "Items API", type: :request do
             expect(parsed[:error]).to eq("Item not found")
         end
     end
+
+    describe "POST /api/v1/items" do
+        it "can create a new item" do
+            item = create(:item)
+
+            post "/api/v1/items", params: {name: item[:name], 
+            description: item[:description],
+            unit_price: item[:unit_price],
+            merchant: item[:merchant]
+            }
+            
+            expect(response).to be_successful
+
+            created_item = JSON.parse(response.body, symbolize_names: true)
+            
+            expect(created_item[:data][:attributes][:name]).to be_a(String)
+            expect(created_item[:data][:attributes][:description]).to be_a(String)
+            expect(created_item[:data][:attributes][:unit_price]).to be_a(Float)
+        end
+    end
+
+    describe "PATCH /api/v1/items/{{item_id}}" do
+        it "can update an existing item" do
+            item = create(:item)
+           
+            patch "/api/v1/items/#{item.id}", params: { name: "NewString"}
+            
+            expect(response).to be_successful
+
+            updated_item = Item.find_by(id: item.id)
+
+            expect(updated_item[:name]).to_not eq(item[:name])
+
+            expect(updated_item[:name]).to eq("NewString")
+        end
+    end
 end

--- a/spec/requests/api/v1/merchants/merchant_request_spec.rb
+++ b/spec/requests/api/v1/merchants/merchant_request_spec.rb
@@ -70,13 +70,13 @@ RSpec.describe "Merchant API", type: :request do
         it "can create a new merchant" do
             merchant = create(:merchant)
 
-            post "/api/v1/merchants", params: {name: merchant[:name]}
+            post "/api/v1/merchants", params: {name: merchant.name}
             
             expect(response).to be_successful
 
             created_merchant = JSON.parse(response.body, symbolize_names: true)
-            
-            expect(created_merchant[:data][:attributes][:name]).to be_a(String)
+
+            expect(created_merchant[:name]).to be_a(String)
         end
     end
 

--- a/spec/requests/api/v1/merchants/merchant_request_spec.rb
+++ b/spec/requests/api/v1/merchants/merchant_request_spec.rb
@@ -65,4 +65,35 @@ RSpec.describe "Merchant API", type: :request do
             expect(parsed[:error]).to eq("Merchant not found")
         end
     end
+
+    describe "POST /api/v1/merchants" do
+        it "can create a new merchant" do
+            merchant = create(:merchant)
+
+            post "/api/v1/merchants", params: {name: merchant[:name]}
+            
+            expect(response).to be_successful
+
+            created_merchant = JSON.parse(response.body, symbolize_names: true)
+            
+            expect(created_merchant[:data][:attributes][:name]).to be_a(String)
+        end
+    end
+
+    describe "PATCH /api/v1/merchants/:id" do
+        it "can update an existing merchant" do
+            merchant = create(:merchant)
+           
+            patch "/api/v1/merchants/#{merchant.id}", params: { name: "NewString" }
+            
+            updated_merchant = Merchant.find_by(id: merchant.id)
+          
+            expect(response).to be_successful
+
+            expect(updated_merchant[:name]).to_not eq("MyString")
+
+            expect(updated_merchant[:name]).to eq("NewString")
+        end
+    end
+    
 end


### PR DESCRIPTION
This branch adds happy path Rspec tests for the four POST/PATCH endpoints in the BE half of our project. All tests are passing and utilize the factory gem to DRY up their code (thanks again to Shadeau for implementing that). I forgot to include sad path tests--will follow up with those in another branch.

I also went ahead and renamed the cross-reference item and merchant controllers to 'merchant_items_controller.rb' and 'items_merchant_controller.rb' for the sake of clarity. I updated the routes.rb to accommodate for this change where necessary.

Finally, I changed most of the routes in routes.rb to work with the included /api/v1 namespace. I was getting errors when attempting to make endpoint requests in Postman due to '/api/v1' being appended an extra time to each route unnecessarily. All routes should now return 200-level status codes in Postman and respond successfully in Rspec if they did not do so already. 

I checked to make sure no existing tests or functionality have been broken by these changes. However, please let me know if I missed something.