### PR TITLE
Added happy/sad paths for finding merchants name (caseinsensitive).

### DIFF
--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -19,6 +19,28 @@ class Api::V1::MerchantsController < ApplicationController
     def update
         render json: Merchant.update(params[:id], merchant_params)
     end
+
+    def find
+        if params[:name].blank?
+            render json: { error: "Name should not be empty" }, status: :bad_request
+            return
+        end
+
+        begin
+            # Rails.logger.info "Received name parameter: #{params[:name].inspect}"
+
+            merchant = Merchant.where( "name ILIKE ?", "%#{params[:name]}%" ).order(:name).first
+
+            if merchant.nil?
+                render json: { data: {} }, status: :ok
+            else
+                render json: MerchantSerializer.new(merchant), status: :ok
+            end
+
+        rescue StandardError => e
+            render json: { error: "Something went wrong: #{e.message}" }, status: :internal_server_error
+        end
+    end
     
     private
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,24 +10,19 @@
 
   # Defines the root path route ("/")
   # root "posts#index"
-  namespace :api do
-    namespace :v1 do
-      resources :merchants, only: [:index, :show]
-        get "/merchants/:merchant_id/items", to: "merchants/items_merchant#index"
-
-
-  get "/merchants", to: "merchants#index"
-  get "/merchants/:id", to: "merchants#show"
-  post "/merchants", to: "merchants#create"
-  patch "/merchants/:id", to: "merchants#update"
-
-  get "/items", to: "items#index"
-  get "/items/:id", to: "items#show"
-  post "/items", to: "items#create"
-  patch "/items/:id", to: "items#update"
-
-      resources :items, only: [:index, :show]
-      get "/items/:item_id/merchant", to: "items/merchant_items#show"
+    namespace :api do
+      namespace :v1 do
+        get "/merchants/find", to: "merchants#find" #watch out for scope! issue was endpoint hit :id before it hit find. returning no data
+    
+        resources :merchants, only: [:index, :show, :create, :update] do
+          get "/items", to: "merchants/items_merchant#index"
+        end
+    
+        resources :items, only: [:index, :show, :create, :update] do
+          get "/merchant", to: "items/merchant_items#show"
+        end
+    
+        get "/items/find_all", to: "items#find_all"
+      end
     end
   end
-end

--- a/spec/requests/api/v1/merchants/merchant_search_request_spec.rb
+++ b/spec/requests/api/v1/merchants/merchant_search_request_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "Merchant Search Request", type: :request do
+    describe "/api/v1/merchants/find" do
+        before :each do
+            @merchant1 = create(:merchant, name: "Turing")
+            @merchant2 = create(:merchant, name: "Ring World")
+            @merchant3 = create(:merchant, name: "NonExistent")
+        end
+
+        it "Happy path, finds first merchant the meets search terms (case-insensitive)" do
+            get "/api/v1/merchants/find?name=ring"
+
+            expect(response).to be_successful
+
+            parsed = JSON.parse(response.body, symbolize_names: true)
+
+            expect(parsed[:data]).to have_key(:id)
+            expect(parsed[:data][:attributes][:name]).to eq("Ring World")
+        end
+
+
+        it "Sad path, returns empty if there is no merchant found" do
+            get "/api/v1/merchants/find?name=unknown"
+
+            expect(response).to be_successful
+
+            parsed = JSON.parse(response.body, symbolize_names: true)
+
+            expect(parsed).to eq({ data: {} })
+        end
+
+        it "Edge case, returns a 400 error if the name parameter is missing" do
+            get "/api/v1/merchants/find"
+    
+            expect(response).to have_http_status(:bad_request)
+            parsed = JSON.parse(response.body, symbolize_names: true)
+    
+            expect(parsed[:error]).to eq("Name should not be empty")
+        end
+    end
+end


### PR DESCRIPTION
	Fixed GET /api/v1/merchants/find route ordering to ensure Rails doesn’t treat "find" as an :id.
	Implemented case-insensitive merchant search using ILIKE in PostgreSQL.
	Handled missing query parameters by returning 400 Bad Request.
	Ensured first alphabetically matching merchant is returned if multiple matches exist.

	Wrote request tests (merchant_search_request_spec.rb) for:
	Happy path: Finds the correct merchant.
	Sad path: Returns { data: {} } if no merchant is found.
	Edge case: Missing name param returns 400.

	•	Fixed test failures caused by accidental matching of "NonExistent" merchant in seed data.
	•	Updated expectations in tests to match { data: {} } for missing merchants.
	•	Committed changes to GitHub (merchants_and_all_items branch).
	•	Ready to implement GET /api/v1/items/find_all.

![the office rage GIF](https://github.com/user-attachments/assets/f52d93d7-b698-4e5d-961f-880fb454662c)
